### PR TITLE
[Pipeline] - Update Dockerfile and workflow for standardized deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     environment:
-      name: 'production'
+      name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ EXPOSE 80
 WORKDIR /app
 COPY --from=build /app ./
 
-ENTRYPOINT ["dotnet", "eKIBRA.Web.dll", "--urls", "http://[::]:80"]
+ENV ASPNETCORE_URLS="http://+"
+
+ENTRYPOINT ["dotnet", "eKIBRA.Web.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 ﻿# https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
-EXPOSE 8080
-EXPOSE 8081
 WORKDIR /src
 
 # copy csproj and restore as distinct layers
@@ -17,6 +15,7 @@ RUN dotnet publish -c release -o /app --no-restore
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 USER $APP_UID
+EXPOSE 80
 WORKDIR /app
 COPY --from=build /app ./
-ENTRYPOINT ["dotnet", "eKIBRA.Web.dll"]
+ENTRYPOINT ["dotnet", "eKIBRA.Web.dll", "--urls", "http://0.0.0.0:80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN dotnet publish -c release -o /app --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 USER $APP_UID
 EXPOSE 80
+
 WORKDIR /app
 COPY --from=build /app ./
-ENTRYPOINT ["dotnet", "eKIBRA.Web.dll", "--urls", "http://0.0.0.0:80"]
+ENTRYPOINT ["dotnet", "eKIBRA.Web.dll", "--urls", "http://+"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ EXPOSE 80
 
 WORKDIR /app
 COPY --from=build /app ./
-ENTRYPOINT ["dotnet", "eKIBRA.Web.dll", "--urls", "http://+"]
+
+ENTRYPOINT ["dotnet", "eKIBRA.Web.dll", "--urls", "http://[::]:80"]


### PR DESCRIPTION
## Title
Replaced exposed ports with a single port 80 in the Dockerfile

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Replaced exposed ports with a single port 80 in the Dockerfile for consistency and updated the entry point to explicitly bind to it. Adjusted GitHub Actions workflow to use a capitalized environment name for improved naming convention.

## Testing
N/A

## Impact
How Azure DevOps will run the container. By definition it internally handles the redirects and certs

## Additional Information
N/A

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings 
